### PR TITLE
support addons which have env-specific imports

### DIFF
--- a/addon-builder/ember-cli-build.js
+++ b/addon-builder/ember-cli-build.js
@@ -23,6 +23,11 @@ var importedCssFiles = [];
 // Files included via app.import need to end up in addon.js
 StubApp.prototype.import = function(assetPath, options) {
   options = options || {};
+  
+  if (typeof asset === 'object') {
+    assetPath = assetPath[this.env];
+  }
+  
   var ext = path.extname(assetPath);
   var isCss = ext === '.css';
   if (isCss) {


### PR DESCRIPTION
`assetPath` can also be an object. This is currently borked for addons such as ember-font-awesome.

https://ember-cli.com/api/classes/EmberApp.html#method_import
https://github.com/martndemus/ember-font-awesome/blob/master/index.js#L95