### PR TITLE
Compile app.scss if exported by the addon

### DIFF
--- a/addon-build-configs/2.11.0/package.json
+++ b/addon-build-configs/2.11.0/package.json
@@ -1,7 +1,7 @@
 {
   "name": "twiddle",
   "version": "0.0.0",
-  "description": "Small description for addon-builder-2-10-0 goes here",
+  "description": "Small description for addon-builder-2-11-0 goes here",
   "private": true,
   "directories": {
     "doc": "doc",
@@ -20,16 +20,18 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
-    "ember-cli": "2.10.0",
+    "ember-cli": "2.11.0",
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-htmlbars-inline-precompile": "^0.3.3",
     "ember-cli-uglify": "^1.2.0",
     "ember-load-initializers": "^0.6.0",
     "ember-resolver": "^2.0.3",
+    "ember-source": "2.11.0",
     "loader.js": "^4.0.10",
 
     "broccoli-funnel": "^1.0.7",
+    "broccoli-concat": "^3.2.2",
     "aws-sdk": "2.4",
     "s3": "4.4.0",
     "quick-temp": "0.1.6"

--- a/addon-builder/Dockerfile
+++ b/addon-builder/Dockerfile
@@ -28,5 +28,5 @@ COPY addon-builder/upload.js /addon-builder/upload.js
 ARG BUILDER_ENVIRONMENT
 COPY config/$BUILDER_ENVIRONMENT.js /addon-builder/build-config.js
 
-ENTRYPOINT ['/addon-builder/build-addon.sh']
+ENTRYPOINT ["/addon-builder/build-addon.sh"]
 EXPOSE 4200

--- a/addon-builder/ember-cli-build.js
+++ b/addon-builder/ember-cli-build.js
@@ -106,6 +106,7 @@ module.exports = function() {
       inputFiles: ['**/*.css'],
       outputFile: '/addon.css',
       allowNone: false,
+      sourceMapConfig: { enabled: false },
       annotation: 'Concat: Addon CSS'
     }),
 
@@ -120,6 +121,7 @@ module.exports = function() {
       inputFiles: ['twiddle/**/*.js'],
       outputFile: '/addon.js',
       allowNone: true,
+      sourceMapConfig: { enabled: false },
       annotation: 'Concat: Addon JS'
     })
   ]);

--- a/addon-builder/ember-cli-build.js
+++ b/addon-builder/ember-cli-build.js
@@ -1,7 +1,8 @@
 /* global require, module */
 var EmberApp = require('ember-cli/lib/broccoli/ember-app');
-var mergeTrees    = require('ember-cli/lib/broccoli/merge-trees');
-var Funnel    = require('broccoli-funnel');
+var mergeTrees = require('ember-cli/lib/broccoli/merge-trees');
+var Funnel = require('broccoli-funnel');
+var concat = require('broccoli-concat');
 var path = require('path');
 
 EmberApp.env = function() { return 'development'; }
@@ -91,16 +92,16 @@ module.exports = function() {
     },
     trees: {
       app: new EmptyTree(),
-      styles: new EmptyTree(['app.css', 'app.scss']),
+      styles: ['app.css', 'app.scss'],
       templates: new EmptyTree(),
       public: new EmptyTree()
     }
   });
 
-  var fullTree = app.appAndDependencies();
+  var fullTree = mergeTrees([app.appAndDependencies(), app.styles()])
 
   return mergeTrees([
-    app.concatFiles(fullTree, {
+    concat(fullTree, {
       headerFiles: importedCssFiles,
       inputFiles: ['**/*.css'],
       outputFile: '/addon.css',
@@ -114,7 +115,7 @@ module.exports = function() {
       allowEmpty:true
     }),
 
-    app.concatFiles(fullTree, {
+    concat(fullTree, {
       headerFiles: importedJsFiles.concat(app.legacyFilesToAppend).concat(['vendor/addons.js']),
       inputFiles: ['twiddle/**/*.js'],
       outputFile: '/addon.js',
@@ -122,6 +123,4 @@ module.exports = function() {
       annotation: 'Concat: Addon JS'
     })
   ]);
-
-  return fullTree;
 };


### PR DESCRIPTION
1. If an addon (ember-paper) exports app.scss, we need to include its postprocessTree
2. Fix app.concatFiles deprecations