### PR TITLE
Update ember-cli-build.js

### DIFF
--- a/addon-builder/ember-cli-build.js
+++ b/addon-builder/ember-cli-build.js
@@ -82,7 +82,6 @@ EmptyTree.prototype.cleanup = function() {
 module.exports = function() {
   var app = new StubApp({
     name: 'twiddle',
-    tests: false,
     sourcemaps: {
       enabled: false
     },


### PR DESCRIPTION
Hey folks

Thanks for this great project!

The Ember app used to install the addons is in development environment
 
Based on the following comment from https://github.com/ember-cli/ember-cli/blob/ac5ed086d8a8bd29cd06341596b3888a4dbc8d40/lib/broccoli/ember-app.js#L158-L163

```
    Initializes the `tests` and `hinting` properties.
    Defaults to `false` unless `ember test` was used or this is *not* a production build.
```

So for development environment this will be set to `true` by default.

There are some issues regarding setting this property as `false`, for example: https://github.com/san650/ember-cli-page-object/issues/308

How is the proper way to test this change?