### PR TITLE
feat: URI Encode package name before fetching.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Build a Docker container.
 For example, this will build a container named `twiddle-addon-builder` using Ember 2.9.0 that will deploy to the staging environment:
 
 ```
-docker build -t twiddle-addon-builder -f addon-builder/Dockerfile --build-arg EMBER_VERSION="2.9.0" --build-arg BUILDER_ENVIRONMENT="staging" .
+docker build -t twiddle-addon-builder -f addon-builder/Dockerfile --build-arg EMBER_VERSION="2.18.0" --build-arg BUILDER_ENVIRONMENT="staging" .
 ```
 
 Build your addon.

--- a/api/addon/get.js
+++ b/api/addon/get.js
@@ -36,13 +36,12 @@ exports.handler = function getAddon(event, context) {
 function resolvePackage(addon, addonVersion, emberVersion) {
   return new Promise(function(resolve, reject) {
     console.log('Resolving addon in NPM');
+    const host = 'registry.npmjs.com';
+    const path =  '/' + encodeURIComponent(addon) + '/' + encodeURIComponent(addonVersion);
 
     emberVersion = resolveBuilderEmberVersion(emberVersion);
 
-    return https.get({
-      host: 'registry.npmjs.com',
-      path: '/' + addon + '/' + addonVersion
-    }, function(response) {
+    return https.get({ host, path }, function(response) {
       var body = '';
       response.on('data', function(d) {
         body += d;
@@ -52,7 +51,7 @@ function resolvePackage(addon, addonVersion, emberVersion) {
         try {
           npmData = JSON.parse(body);
         } catch(error) {
-          reject(`Failed to parse json from registry.npmjs.com/${addon}/${addonVersion}: Error: ${error}`);
+          reject(`Failed to parse json from ${host}${path}: Error: ${error}`);
         }
         var npmData = JSON.parse(body);
         if (isValidAddon(npmData)) {


### PR DESCRIPTION
Enables use of namespaced packages. Otherwise the request to NPM fails.

Resolves https://github.com/ember-cli/ember-twiddle/issues/657